### PR TITLE
attestation variants validation

### DIFF
--- a/app/src/forms/attestations/agriseafoodopscreening/models/form.js
+++ b/app/src/forms/attestations/agriseafoodopscreening/models/form.js
@@ -121,6 +121,24 @@ class Attestation extends AttestationModels.AttestationTransportation {
     return PREFIX;
   }
 
+  static get jsonSchema() {
+    const schemaProperties = {...AttestationModels.AttestationTransportationSchema.properties};
+    // need to remove some properties
+    delete schemaProperties.sharedSleepingPerRoom;
+    delete schemaProperties.sleepingAreaType;
+    delete schemaProperties.commonAreaDistancing;
+    // and add the new one.
+    schemaProperties.sharedSleepingCommunication = {type: 'boolean'};
+    return {
+      type: 'object',
+      required: Object.keys(schemaProperties).map(x => x),
+      properties: {
+        ...schemaProperties,
+        ...CommonModels.stamps
+      },
+      additionalProperties: false
+    };
+  }
 }
 
 class Business extends AttestationModels.Business {

--- a/app/src/forms/attestations/minesoperatorscreening/models/form.js
+++ b/app/src/forms/attestations/minesoperatorscreening/models/form.js
@@ -101,7 +101,7 @@ class Submission extends AttestationModels.Submission {
 
 }
 
-class Attestation extends AttestationModels.Attestation {
+class Attestation extends AttestationModels.AttestationTransportation {
   static get tablePrefix() {
     return PREFIX;
   }

--- a/app/src/forms/attestations/models/submission.js
+++ b/app/src/forms/attestations/models/submission.js
@@ -304,7 +304,6 @@ class OperationType extends CommonModels.Timestamps(Model) {
 }
 
 const AttestationSchema = {
-  required: ['attestationId', 'submissionId'],
   properties: {
     attestationId: {type: 'string', pattern: constants.UUID_REGEX},
     submissionId: {type: 'string', pattern: constants.UUID_REGEX},
@@ -317,7 +316,6 @@ const AttestationSchema = {
     workerContactPersonnel: {type: 'boolean'},
     commonAreaDistancing: {type: 'boolean'},
     sharedSleepingDistancing: {type: 'boolean'},
-    sharedSleepingCommunication: {type: 'boolean'},
     selfIsolateUnderstood: {type: 'boolean'},
     selfIsolateAccommodation: {type: 'boolean'},
     laundryServices: {type: 'boolean'},
@@ -351,13 +349,7 @@ const AttestationSchema = {
     infectedHousekeeping: {type: 'boolean'},
     infectedWaste: {type: 'boolean'},
     certifyAccurateInformation: {type: 'boolean'},
-    agreeToInspection: {type: 'boolean'},
-    transportationSingleOccupant: {type: 'boolean'},
-    transportationBusesVans: {type: 'boolean'},
-    transportationTrucksCars: {type: 'boolean'},
-    transportationHelicopter: {type: 'boolean'},
-    transportationTravelPod: {type: 'boolean'},
-    transportationCleaningDistancing: {type: 'boolean'}
+    agreeToInspection: {type: 'boolean'}
   }
 };
 
@@ -373,7 +365,7 @@ class Attestation extends CommonModels.Timestamps(Model) {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: AttestationSchema.required,
+      required: Object.keys(AttestationSchema.properties).map(x => x),
       properties: {
         ...AttestationSchema.properties,
         ...CommonModels.stamps
@@ -383,19 +375,25 @@ class Attestation extends CommonModels.Timestamps(Model) {
   }
 }
 
+const AttestationTransportationSchema = {
+  properties: {
+    ...AttestationSchema.properties,
+    transportationSingleOccupant: {type: 'boolean'},
+    transportationBusesVans: {type: 'boolean'},
+    transportationTrucksCars: {type: 'boolean'},
+    transportationHelicopter: {type: 'boolean'},
+    transportationTravelPod: {type: 'boolean'},
+    transportationCleaningDistancing: {type: 'boolean'}
+  }
+};
+
 class AttestationTransportation extends Attestation {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: AttestationSchema.required,
+      required: Object.keys(AttestationTransportationSchema.properties).map(x => x),
       properties: {
-        ...AttestationSchema.properties,
-        transportationSingleOccupant: {type: 'boolean'},
-        transportationBusesVans: {type: 'boolean'},
-        transportationTrucksCars: {type: 'boolean'},
-        transportationHelicopter: {type: 'boolean'},
-        transportationTravelPod: {type: 'boolean'},
-        transportationCleaningDistancing: {type: 'boolean'},
+        ...AttestationTransportationSchema.properties,
         ...CommonModels.stamps
       },
       additionalProperties: false
@@ -551,7 +549,9 @@ class LocationMines extends Location {
 
 module.exports = {
   Attestation: Attestation,
+  AttestationSchema: AttestationSchema,
   AttestationTransportation: AttestationTransportation,
+  AttestationTransportationSchema: AttestationTransportationSchema,
   Business: Business,
   Contact: Contact,
   Location: Location,


### PR DESCRIPTION
Re-work the validation for attestations.
We now have 3 slightly different attestations, so change the jsonSchema accordingly for each type.
During testing, it became apparent that ALL the fields should be required because even with not nullable and default to false in the db for booleans, the field still needs to be passed in or the insert statement fails.  So making all attestation fields (except user/time stamps) required.

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->